### PR TITLE
Send pings as a custom `ping` event

### DIFF
--- a/sse_starlette/sse.py
+++ b/sse_starlette/sse.py
@@ -206,6 +206,6 @@ class EventSourceResponse(Response):
         # (one starting with a ':' character) every 15 seconds or so.
         while self.active:
             await asyncio.sleep(self._ping_interval)
-            ping = ServerSentEvent(f": ping {datetime.utcnow()}").encode()
+            ping = ServerSentEvent(datetime.utcnow(), event="ping").encode()
             _log.debug(f"ping: {ping.decode()}")
             await send({"type": "http.response.body", "body": ping, "more_body": True})


### PR DESCRIPTION
# Problem

Pings are muddling `message` events when it is [intended](https://github.com/sysid/sse-starlette/blob/master/sse_starlette/sse.py#L204-L206) that `pings` are sent as "comments" 

![Screen Shot 2020-06-04 at 4 00 59 PM](https://user-images.githubusercontent.com/13646646/83818623-b0c3d100-a67c-11ea-894c-bbc85d384c3b.png)
*Network tab in dev-tools* 

The ping string `: ping [TIMESTAMP]` is sent through the `data` field when it should be on a line on its own (as seen in the [MDN example](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#Data-only_messages)) for it to be recognized as a comment.

# To reproduce
Given a simple SSE endpoint that streams numbers:

```python
@app.get("/sse")
async def sse(req: Request):
    async def streamNumbers(num):
        i = 0
        while i <= num:
            disconnected = await req.is_disconnected()
            if disconnected:
                break
            yield i
            i += 1
            await asyncio.sleep(1)
    return EventSourceResponse(streamNumbers(10000))
```

# Proposed

An easier/cleaner fix than making the ping a comment in the stream is to send the ping as a `ping` event. This is reflected in MDN doc's example of [receiving](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#Receiving_events_from_the_server) and [sending events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#Sending_events_from_the_server).


