### PR TITLE
feat: add py.typed for enable type checking

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
     long_description_content_type='text/markdown',
     author='sysid',
     author_email='sysid@gmx.de',
+    package_data={"sse_starlette": ["py.typed"]},
     packages=get_packages('sse_starlette'),
     install_requires=[],
     classifiers=[


### PR DESCRIPTION
# What
I added starlette/py.typed file and update setup.py to include "package_data" line.

# Why

I tried to use sse-starlette with mypy, but it claims `Skipping analyzing 'sse_starlette.sse': found module but no type hints or library stubs`.

I found that's probably because of lack of py.typed file (PEP 561).