### PR TITLE
Explicit handling of refresh/tab-close in the examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,16 +50,20 @@ Client disconnects need to be handled in the Request handler (see example.py):
 async def endless(req: Request):
     async def event_publisher():
         i = 0
-        while True:
-            disconnected = await req.is_disconnected()
-            if disconnected:
-                _log.info(f"Disconnecting client {req.client}")
-                break
-            i += 1
-            yield dict(data=i)
-            await asyncio.sleep(0.2)
-        _log.info(f"Disconnected from client {req.client}")
-
+        try:
+          while True:
+              disconnected = await req.is_disconnected()
+              if disconnected:
+                  _log.info(f"Disconnecting client {req.client}")
+                  break
+              i += 1
+              yield dict(data=i)
+              await asyncio.sleep(0.2)
+          _log.info(f"Disconnected from client {req.client}")
+        except asyncio.CancelledError as e:
+          _log.info(f"Disconnected from client (via refresh/close) {req.client}")
+          # Do any other cleanup, if any
+          raise e
     return EventSourceResponse(event_publisher())
 ```
 

--- a/example.py
+++ b/example.py
@@ -58,7 +58,7 @@ async def endless(req: Request):
                 yield dict(data=i)
                 await asyncio.sleep(0.9)
             _log.info(f"Disconnected from client {req.client}")
-        except CancelledError as e:
+        except asyncio.CancelledError as e:
             _log.info(f"Disconnected from client (via refresh/close) {req.client}")
             # Do any other cleanup, if any
             raise e

--- a/example.py
+++ b/example.py
@@ -47,18 +47,21 @@ async def endless(req: Request):
 
     async def event_publisher():
         i = 0
-
-        while True:
-            disconnected = await req.is_disconnected()
-            if disconnected:
-                _log.info(f"Disconnecting client {req.client}")
-                break
-            # yield dict(id=..., event=..., data=...)
-            i += 1
-            yield dict(data=i)
-            await asyncio.sleep(0.9)
-        _log.info(f"Disconnected from client {req.client}")
-
+        try:
+            while True:
+                disconnected = await req.is_disconnected()
+                if disconnected:
+                    _log.info(f"Disconnecting client {req.client}")
+                    break
+                # yield dict(id=..., event=..., data=...)
+                i += 1
+                yield dict(data=i)
+                await asyncio.sleep(0.9)
+            _log.info(f"Disconnected from client {req.client}")
+        except CancelledError as e:
+            _log.info(f"Disconnected from client (via refresh/close) {req.client}")
+            # Do any other cleanup, if any
+            raise e
     return EventSourceResponse(event_publisher())
 
 


### PR DESCRIPTION
Hopefully this will help clarity for future users of sse-starlette. This is an update to the documentation to show handling of connection closes due to refresh/tab-closing. Starlette doesn't disconnect the request, it cancels the future/task. Therefore checking for `req.is_disconnected()` won't ever get called and it will just die. Wrapping it all in a try/except CancelledError will keep the loop from dying (giving you time to cleanup, log, or anything else)