### PR TITLE
update fastapi example to use conditional yielding endpoint 

### DIFF
--- a/example_fastapi.py
+++ b/example_fastapi.py
@@ -21,16 +21,18 @@ async def endless(req: Request):
     """
 
     async def event_publisher():
-        i = 0
+        # The event publisher only conditionally emits items
+        has_data = True
 
         while True:
             disconnected = await req.is_disconnected()
             if disconnected:
                 _log.info(f"Disconnecting client {req.client}")
                 break
-            # yield dict(id=..., event=..., data=...)
-            i += 1
-            yield dict(data=i)
+            # Simulate only sending one response
+            if has_data:
+                yield dict(data="u can haz the data")
+                has_data = False
             await asyncio.sleep(0.9)
         _log.info(f"Disconnected from client {req.client}")
 


### PR DESCRIPTION
Hi, thanks for the nice library :wave:

I have a FastAPI endpoint that is similar to your example, but only yields when there is new data. As a consequence your AppStatus check does not force my endpoint to close, because there is no yielded item to get into the codepath that checks AppStatus.

I updated your fastapi example to reflect this use-case and added a third task to `run_until_first_complete` that checks the uvicorn exit status at a regular interval.