### PR TITLE
fix: allowing python 3.6 and 3.7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.8, 3.9 ]
+        python-version: [ 3.6, 3.7, 3.8, 3.9 ]
 
     env:
       USING_COVERAGE: "3.9"

--- a/Pipfile
+++ b/Pipfile
@@ -19,4 +19,4 @@ uvicorn = "*"
 fastapi = "*"
 
 [requires]
-python_version = "3.8"
+python_version = "3"

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ packages = find:
 install_requires =
     starlette
 include_package_data = True
-python_requires = >=3.8
+python_requires = >=3.6
 
 [options.packages.find]
 ;where = snipsync  ; gotcha: was not importable as snipsync


### PR DESCRIPTION
Hi,

Python 3.6 and 3.7 where not allowed given the constraints even if starlette supports 3.6 and 3.7.
Tests pass with both 3.6 and 3.7.
This commit changes the constraints to allow these versions.

Python 3.6:
```shell
============================================================================================================ test session starts ============================================================================================================
platform linux -- Python 3.6.13, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
rootdir: .../sse-starlette
plugins: asyncio-0.15.1, anyio-3.3.2
collected 23 items

tests/test_sse.py .......................                                                                                                                                                                                             [100%]

============================================================================================================ 23 passed in 1.77s =============================================================================================================
```


Python 3.7:

```bash
============================================================================================================ test session starts ============================================================================================================
platform linux -- Python 3.7.10, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
rootdir: /mnt/c/Users/Cyprien/Documents/GitHub/sse-starlette
plugins: asyncio-0.15.1, anyio-3.3.2
collected 23 items

tests/test_sse.py .......................                                                                                                                                                                                             [100%]

============================================================================================================ 23 passed in 1.75s =============================================================================================================
```