### PR TITLE
feat(sse/cache-control): allow user to set cache-control header

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,13 @@ make test
 
 ## Special use cases
 ### Fan out Proxies
-Fan out proxies usually rely on response being cacheable to support that you can provide the `Content-Type` header to  `EventSourceResponse`
+Fan out proxies usually rely on response being cacheable. To support that, you can set the value of `Cache-Control`.
+For example:
+```python
+return EventSourceResponse(
+        generator(), headers={"Cache-Control": "public, max-age=29"}
+    )
+```
 
 ## Changelog
 ### 1.0.0 (2022-07-24)

--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ Run the tests:
 make test
 ```
 
+## Special use cases
+### Fan out Proxies
+Fan out proxies usually rely on response being cacheable to support that you can provide the `Content-Type` header to  `EventSourceResponse`
+
 ## Changelog
 ### 1.0.0 (2022-07-24)
 - drop support for python 3.6 and 3.7

--- a/sse_starlette/sse.py
+++ b/sse_starlette/sse.py
@@ -168,7 +168,9 @@ class EventSourceResponse(Response):
             _headers.update(headers)
 
         # mandatory for servers-sent events headers
-        _headers["Cache-Control"] = "no-cache"
+        # allow cache control header to be set by user to support fan out proxies
+        # https://www.fastly.com/blog/server-sent-events-fastly
+        _headers.setdefault("Cache-Control", "no-cache")
         _headers["Connection"] = "keep-alive"
         _headers["X-Accel-Buffering"] = "no"
 


### PR DESCRIPTION
To support fan out proxies like fastly the response needs to
be cacheable.
ref: https://github.com/sysid/sse-starlette/issues/34

closes https://github.com/sysid/sse-starlette/issues/34