### PR TITLE
feat: send default ping as comment message

### DIFF
--- a/sse_starlette/sse.py
+++ b/sse_starlette/sse.py
@@ -257,7 +257,7 @@ class EventSourceResponse(Response):
             if self.ping_message_factory:
                 assert isinstance(self.ping_message_factory, Callable)  # type: ignore  # https://github.com/python/mypy/issues/6864
             ping = (
-                ServerSentEvent(datetime.utcnow(), event="ping").encode()
+                ServerSentEvent(datetime.utcnow(), event=": ping").encode()
                 if self.ping_message_factory is None
                 else ensure_bytes(self.ping_message_factory())
             )


### PR DESCRIPTION
Send default ping payload as a comment line,
as recommended by the RFC https://html.spec.whatwg.org/multipage/server-sent-events.html#authoring-notes

Prevents some clients to raise an error when parsing the payload.