### PR TITLE
feat: Send pings as comments by default

### DIFF
--- a/sse_starlette/sse.py
+++ b/sse_starlette/sse.py
@@ -272,7 +272,7 @@ class EventSourceResponse(Response):
             if self.ping_message_factory:
                 assert isinstance(self.ping_message_factory, Callable)  # type: ignore  # https://github.com/python/mypy/issues/6864
             ping = (
-                ServerSentEvent(datetime.utcnow(), event="ping").encode()
+                ServerSentEvent(comment=datetime.utcnow()).encode()
                 if self.ping_message_factory is None
                 else ensure_bytes(self.ping_message_factory())
             )

--- a/sse_starlette/sse.py
+++ b/sse_starlette/sse.py
@@ -272,7 +272,7 @@ class EventSourceResponse(Response):
             if self.ping_message_factory:
                 assert isinstance(self.ping_message_factory, Callable)  # type: ignore  # https://github.com/python/mypy/issues/6864
             ping = (
-                ServerSentEvent(comment=datetime.utcnow()).encode()
+                ServerSentEvent(comment=f"ping - {datetime.utcnow()}").encode()
                 if self.ping_message_factory is None
                 else ensure_bytes(self.ping_message_factory())
             )

--- a/sse_starlette/sse.py
+++ b/sse_starlette/sse.py
@@ -97,7 +97,6 @@ class ServerSentEvent:
             for chunk in self.LINE_SEP_EXPR.split(str(self.comment)):
                 buffer.write(f": {chunk}")
                 buffer.write(self._sep)
-            return buffer.getvalue().encode("utf-8")
 
         if self.id is not None:
             buffer.write(self.LINE_SEP_EXPR.sub("", f"id: {self.id}"))
@@ -107,9 +106,10 @@ class ServerSentEvent:
             buffer.write(self.LINE_SEP_EXPR.sub("", f"event: {self.event}"))
             buffer.write(self._sep)
 
-        for chunk in self.LINE_SEP_EXPR.split(str(self.data)):
-            buffer.write(f"data: {chunk}")
-            buffer.write(self._sep)
+        if self.data is not None:
+            for chunk in self.LINE_SEP_EXPR.split(str(self.data)):
+                buffer.write(f"data: {chunk}")
+                buffer.write(self._sep)
 
         if self.retry is not None:
             if not isinstance(self.retry, int):

--- a/tests/test_sse.py
+++ b/tests/test_sse.py
@@ -25,6 +25,10 @@ def test_compression_not_implemented():
             dict(comment="a comment"),
             b": a comment\r\n\r\n",
         ),
+        (
+            dict(data="foo", comment="a comment"),
+            b": a comment\r\ndata: foo\r\n\r\n",
+        ),
     ],
 )
 def test_server_sent_event(input, expected):

--- a/tests/test_sse.py
+++ b/tests/test_sse.py
@@ -1,6 +1,7 @@
 import pytest
 from sse_starlette.sse import EventSourceResponse, ServerSentEvent
 
+
 def test_compression_not_implemented():
     response = EventSourceResponse(0)
     with pytest.raises(NotImplementedError):

--- a/tests/test_sse.py
+++ b/tests/test_sse.py
@@ -1,6 +1,6 @@
 import pytest
 from sse_starlette.sse import EventSourceResponse, ServerSentEvent
-
+from datetime import datetime
 
 def test_compression_not_implemented():
     response = EventSourceResponse(0)
@@ -20,6 +20,10 @@ def test_compression_not_implemented():
         (
             dict(data="foo", event="bar", id="xyz", retry=1),
             b"id: xyz\r\nevent: bar\r\ndata: foo\r\nretry: 1\r\n\r\n",
+        ),
+        (
+            dict(comment="a comment"),
+            b": a comment\r\n\r\n",
         ),
     ],
 )

--- a/tests/test_sse.py
+++ b/tests/test_sse.py
@@ -1,6 +1,5 @@
 import pytest
 from sse_starlette.sse import EventSourceResponse, ServerSentEvent
-from datetime import datetime
 
 def test_compression_not_implemented():
     response = EventSourceResponse(0)


### PR DESCRIPTION
Given 3 users who have made a comment on the ping events in #51 and #44 -- it might be best to send pings as comments by default, that way clients don't have to deal with them out-of-the box.

To achieve this, we can change the ping from an event data to an event comment as seen on this changeset, 

![image](https://user-images.githubusercontent.com/13646646/235335020-165a031d-7952-4708-b4c1-fa81732a6e8f.png)

However, the package does not seem to be encoding the events properly when a comment is included in the event. Examples,

1. If the event only includes a comment, `ServerSentEvent(comment="a comment")`, then
- expected encoded event is `: a comment\r\n\r\n`
- but actual encoded event is: `: a comment\r\n`
2. If the event includes data and a comment, `ServerSentEvent(data="some data", comment="a comment")`
- expected encoded event is `: a comment\r\ndata: some data\r\n\r\n`
- but actual encoded event is: `: a comment\r\n`

If I understand the spec correctly (screenshot below) I think the expected data specified above is correct. Let me know otherwise!
![image](https://user-images.githubusercontent.com/13646646/235334723-dfb52c5f-9dab-4442-a5e6-54619532133c.png)
(from https://html.spec.whatwg.org/multipage/server-sent-events.html)

# Testing

1. Test cases that include comments in events, were added and they pass
2. Existing tests pass
3. Manual E2E test shows that a ping has been sent as a comment; and since it's sent as a comment, it's not parsed by the browser as a `message` or `data`
![image](https://user-images.githubusercontent.com/13646646/235335559-512b1ec7-6759-4756-917d-60292d87f59c.png)

