### PR TITLE
Allow Usage without Async Generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ return EventSourceResponse(
 ### Error Handling
 See example: `examples/error_handling.py`
 
+### Sending Responses without Async Generators
+See example: `examples/no_async_generators.py`
+
+Async generators do not guarantee when things like finally blocks run
+in all cases and so can be a footgun. This shows an alternative implementation
+that does not rely on async generators but instead uses memory channels.
 
 ## Development, Contributing
 1. install pipenv: `pip install pipenv`

--- a/README.md
+++ b/README.md
@@ -94,12 +94,15 @@ return EventSourceResponse(
 ### Error Handling
 See example: `examples/error_handling.py`
 
-### Sending Responses without Async Generators
-See example: `examples/no_async_generators.py`
 
-Async generators do not guarantee when things like finally blocks run
-in all cases and so can be a footgun. This shows an alternative implementation
-that does not rely on async generators but instead uses memory channels.
+### Sending Responses without Async Generators
+Async generators can expose tricky error and cleanup behavior especially when they are interrupted.
+
+[Background: Cleanup in async generators](https://vorpus.org/blog/some-thoughts-on-asynchronous-api-design-in-a-post-asyncawait-world/#cleanup-in-generators-and-async-generators).
+
+Example [`no_async_generators.py`](https://github.com/sysid/sse-starlette/pull/56#issue-1704495339) shows an alternative implementation
+that does not rely on async generators but instead uses memory channels (`examples/no_async_generators.py`).
+
 
 ## Development, Contributing
 1. install pipenv: `pip install pipenv`

--- a/examples/no_async_generators.py
+++ b/examples/no_async_generators.py
@@ -1,0 +1,76 @@
+import anyio
+import logging
+from anyio.streams.memory import MemoryObjectSendStream
+from functools import partial
+
+import trio
+import uvicorn
+from fastapi import FastAPI
+from sse_starlette.sse import EventSourceResponse
+from starlette.requests import Request
+
+_log = logging.getLogger(__name__)
+log_fmt = r"%(asctime)-15s %(levelname)s %(name)s %(funcName)s:%(lineno)d %(message)s"
+datefmt = "%Y-%m-%d %H:%M:%S"
+logging.basicConfig(format=log_fmt, level=logging.DEBUG, datefmt=datefmt)
+
+app = FastAPI()
+
+
+@app.get("/endless")
+async def endless(req: Request):
+    """Simulates an endless stream
+
+    In case of server shutdown the running task has to be stopped via signal handler in order
+    to enable proper server shutdown. Otherwise, there will be dangling tasks preventing proper shutdown.
+    """
+    send_chan, recv_chan = anyio.create_memory_object_stream(10)
+    async def event_publisher(inner_send_chan: MemoryObjectSendStream):
+        async with inner_send_chan:
+            try: 
+                i = 0
+                while True:
+                    i += 1
+                    await inner_send_chan.send(dict(data=i))
+                    await anyio.sleep(1.0)
+            except anyio.get_cancelled_exc_class() as e:
+                _log.info(f"Disconnected from client (via refresh/close) {req.client}")
+                with anyio.move_on_after(1, shield=True):
+                    await inner_send_chan.send(dict(closing=True))
+                    raise e
+
+    return EventSourceResponse(recv_chan, data_sender_callable=partial(event_publisher, send_chan))
+
+
+
+@app.get("/endless-trio")
+async def endless_trio(req: Request):
+    """Simulates an endless stream
+
+    In case of server shutdown the running task has to be stopped via signal handler in order
+    to enable proper server shutdown. Otherwise, there will be dangling tasks preventing proper shutdown.
+    """
+    raise Exception("Trio is not compatible with uvicorn, this code is for example purposes")
+
+    send_chan, recv_chan = trio.open_memory_channel(10)
+    async def event_publisher(inner_send_chan: trio.MemorySendChannel):
+        async with inner_send_chan:
+            try: 
+                i = 0
+                while True:
+                    i += 1
+                    await inner_send_chan.send(dict(data=i))
+                    await trio.sleep(1.0)
+            except trio.Cancelled as e:
+                _log.info(f"Disconnected from client (via refresh/close) {req.client}")
+                with anyio.move_on_after(1, shield=True):
+                    # This may not make it 
+                    await inner_send_chan.send(dict(closing=True))
+                    raise e
+
+    return EventSourceResponse(recv_chan, data_sender_callable=partial(event_publisher, send_chan))
+
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8080, log_level="trace", log_config=None)  # type: ignore


### PR DESCRIPTION
This PR adds a new option that runs the code that generates responses in the same TaskGroup that is used for streaming the response. Doing so avoids the need for an async generator or some other form of persistent iterator that exists across requests.

The motivation for doing that is that async generators have less well defined error and cleanup behavior especially when they are interrupted [see here](https://vorpus.org/blog/some-thoughts-on-asynchronous-api-design-in-a-post-asyncawait-world/#cleanup-in-generators-and-async-generators).

In this new implementation, the coroutine that is generating outputs can be straightforwardly cancelled just like all the others in response to disconnects or server shutdowns and will be able to run its cleanup code right then and there which makes it easier to understand what is going to happen in all cases and importantly to propagate _all_ exceptions where they should go.

This is conceptually similar to what is being done in the stream generator examples except it works within a single endpoint and doesn't require any shared state.