### PR TITLE
fix: there should be only one exit event

### DIFF
--- a/sse_starlette/sse.py
+++ b/sse_starlette/sse.py
@@ -202,7 +202,8 @@ class EventSourceResponse(Response):
             return
 
         # Setup an Event
-        AppStatus.should_exit_event = anyio.Event()
+        if AppStatus.should_exit_event is None:
+            AppStatus.should_exit_event = anyio.Event()
 
         # Check if should_exit got set while we set up the event
         if AppStatus.should_exit:


### PR DESCRIPTION
So `AppStatus.should_exit_event` got rewrited in `listen_for_exit_signal` with every new connection being made and old connections remain in connected state when server stops.
This fixes that.