### PR TITLE
fix type of SSE "id" field (int->str)

### DIFF
--- a/sse_starlette/sse.py
+++ b/sse_starlette/sse.py
@@ -53,7 +53,7 @@ class ServerSentEvent:
         data: Optional[Any] = None,
         *,
         event: Optional[str] = None,
-        id: Optional[int] = None,
+        id: Optional[str] = None,
         retry: Optional[int] = None,
         comment: Optional[str] = None,
         sep: Optional[str] = None,


### PR DESCRIPTION
- the spec defines "id" as an opaque UTF-8 string with no NUL/CR/LF bytes
- the type in the doc string was already correct

https://html.spec.whatwg.org/multipage/server-sent-events.html#the-last-event-id-header