### PR TITLE
Avoid calling `decode()` and allocating strings for logging if said log lines will no-op anyways.

### DIFF
--- a/sse_starlette/sse.py
+++ b/sse_starlette/sse.py
@@ -250,7 +250,7 @@ class EventSourceResponse(Response):
         )
         async for data in self.body_iterator:
             chunk = ensure_bytes(data, self.sep)
-            _log.debug(f"chunk: {chunk.decode()}")
+            if _log.isEnabledFor(logging.DEBUG): _log.debug(f"chunk: {chunk.decode()}")
             with anyio.move_on_after(self.send_timeout) as timeout:
                 await send(
                     {"type": "http.response.body", "body": chunk, "more_body": True}
@@ -322,7 +322,7 @@ class EventSourceResponse(Response):
                 if self.ping_message_factory is None
                 else ensure_bytes(self.ping_message_factory(), self.sep)
             )
-            _log.debug(f"ping: {ping.decode()}")
+            if _log.isEnabledFor(logging.DEBUG): _log.debug(f"ping: {ping.decode()}")
             async with self._send_lock:
                 if self.active:
                     await send(


### PR DESCRIPTION
These lines were throwing in my use case because `chunk` was not a valid UTF-8 byte sequence.

Even when these lines don't throw exceptions, they're still a performance penalty incurred in cases where the `chunk` object is large: The f-string is evaluated and allocated, even if the log level means that the debug logs are skipped, because the arguments to the `_log.debug()` function must be computed before the function can be called.

This PR proposes a simple fix.