### PR TITLE
Cleanup unused loops

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ __pycache__/
 venv/
 Pipfile.lock
 .envrc
+.pdm-python

--- a/.pdm-python
+++ b/.pdm-python
@@ -1,1 +1,0 @@
-/Users/Q187392/dev/s/public/sse-starlette/.venv/bin/python

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ that does not rely on async generators but instead uses memory channels (`exampl
 
 ## Development, Contributing
 1. install pdm: `pip install pdm`
-2. install dependencies using pipenv: `pdm install -d.`
+2. install dependencies using pipenv: `pdm install -d`.
 3. To run tests:
 
 ### Makefile

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ that does not rely on async generators but instead uses memory channels (`exampl
 ### Makefile
 - make sure your virtualenv is active
 - check `Makefile` for available commands and development support, e.g. run the unit tests:
-```python
+```shell
 make test
 make tox
 ```

--- a/tests/integration/test_multiple_consumers.py
+++ b/tests/integration/test_multiple_consumers.py
@@ -155,10 +155,9 @@ def test_stop_server_with_many_consumers(caplog, server_command, expected_lines)
     if server_process is None or server_process.poll() is not None:
         pytest.fail("Server did not start.")
 
-    # Initialize asyncio loops and threads
-    loops = [asyncio.new_event_loop() for _ in range(N_CONSUMER)]
+    # Initialize threads
     threads = []
-    for loop in loops:
+    for _ in range(N_CONSUMER):
         thread = threading.Thread(
             target=lambda: asyncio.run(
                 make_arequest(f"{URL}:{port}/endless", expected_lines=expected_lines)


### PR DESCRIPTION
As we talked about in the commit comments, here is my PR removing the unused event loop.

During development I found some small typos in the README.md which I took the liberty to fix.

Creating and activating my development environment the content of .pdm-python changed, I removed the file from the repo and added it to git ignore since it contains a machine specific path to a virtual environment.