### PR TITLE
Change default cache-control response to 'no-store'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ style: sort-imports format  ## perform code style format (black, isort)
 
 .PHONY: lint
 lint:  ## check style with ruff
-	ruff $(pkg_src) $(tests_src)
+	ruff check $(pkg_src) $(tests_src)
 
 .PHONY: mypy
 mypy:  ## check type hint annotations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ dev = [
     "asgi-lifespan",
     "psutil",
     "black>=23.11.0",
+    "ruff",
 ]
 
 [tool.isort]


### PR DESCRIPTION
The default cache-control header returned by sse-starlete is
"no-cache", which (confusingly!) does not actually mean "don't cache",
but instead that caching is allowed but the result must be
re-validated on each fetch.  [From MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control):

> The no-cache response directive indicates that the response can be
> stored in caches, but the response must be validated with the origin
> server before each reuse, even when the cache is disconnected from
> the origin server.

This is *probably* harmless as long as there's not an ETag or
Last-Modified header that would allow revalidation, but it does make
it much easier to unexpectedly enable caching or globally audit cache
behavior.

This PR:

 * Changes the default to "no-store", which does disallow caching

 * Uses starlette's `MutableHeaders` to build the headers; this
   normalizes to all lower-case so we're independent of case if an
   explicit cache-control is passed in.

 * Adds a test for header handling.

 * Adds ruff to the dev dependencies and updates `make lint` to
   resolve a deprecation warning in the command.
