### PR TITLE
add missing test dependencies to tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,8 @@ deps =
     uvicorn
     starlette
     fastapi
+    testcontainers
+    async-timeout
 commands =
     #pytest --cov=sse_starlette --cov-report=xml
     coverage erase


### PR DESCRIPTION
`testcontainers` and `async-timeout` are listed in GHA workflow, but are missed in `tox.ini`.
I think that's a good idea to add them to `tox.ini` for people, who run tests locally.