### PR TITLE
Fix streaming examples cannot be running in python3.9

### DIFF
--- a/examples/stream_generator_multiple.py
+++ b/examples/stream_generator_multiple.py
@@ -12,25 +12,27 @@ This example shows how to use multiple streams.
 
 class Stream:
     def __init__(self) -> None:
-        self._queue = asyncio.Queue[ServerSentEvent]()
+        self._queue = None
+
+    @property
+    def queue(self):
+        if self._queue is None:
+            self._queue = asyncio.Queue[ServerSentEvent]()
+        return self._queue
 
     def __aiter__(self) -> "Stream":
         return self
 
     async def __anext__(self) -> ServerSentEvent:
-        return await self._queue.get()
+        return await self.queue.get()
 
     async def asend(self, value: ServerSentEvent) -> None:
-        await self._queue.put(value)
+        await self.queue.put(value)
 
 
 app = FastAPI()
 
-# _stream = Stream()
 _streams: List[Stream] = []
-
-
-# app.dependency_overrides[Stream] = lambda: _stream
 
 
 @app.get("/sse")
@@ -51,4 +53,4 @@ async def send_message(message: str, stream: Stream = Depends()) -> None:
 if __name__ == "__main__":
     import uvicorn
 
-    uvicorn.run(app, host="127.0.0.1", port=8000)
+    uvicorn.run(app, host="127.0.0.1", port=8000, log_level="trace")


### PR DESCRIPTION
Problem:

`asyncio.Queue()` should be called inside `asyncio.run()`, because it used `asyncio.get_event_loop()` / `asyncio.get_running_loop()`.

Solution:

delay initialized `Stream._queue`.
