### PR TITLE
Fix the type annotation on client_close_handler_callable

### DIFF
--- a/sse_starlette/sse.py
+++ b/sse_starlette/sse.py
@@ -84,7 +84,7 @@ class EventSourceResponse(Response):
             Callable[[], Coroutine[None, None, None]]
         ] = None,
         send_timeout: Optional[float] = None,
-        client_close_handler_callable: Optional[Callable[[Message], None]] = None,
+        client_close_handler_callable: Optional[Callable[[Message], Awaitable[None]]] = None,
     ) -> None:
         # Validate separator
         if sep not in (None, "\r\n", "\r", "\n"):


### PR DESCRIPTION
The current annotation is not for async method, which led me to pass in a sync method and produced very cryptic error messages. 

Another related issue: wrong type annotation leads to wrong decoration in python IDEs.