### PR TITLE
Add an `JSONServerSentEvent` utility based on starlette `JSONResponse`

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,18 @@ event = ServerSentEvent(
 )
 ```
 
+### JSONServerSentEvent
+
+For an easy way to send json data as SSE events:
+
+```python
+from sse_starlette import JSONServerSentEvent
+
+event = JSONServerSentEvent(
+    data={"field":"value"}, # Anything serializable with json.dumps
+)
+```
+
 ## Advanced Usage
 
 ### Custom Ping Configuration

--- a/sse_starlette/__init__.py
+++ b/sse_starlette/__init__.py
@@ -1,5 +1,5 @@
-from sse_starlette.event import ServerSentEvent
+from sse_starlette.event import ServerSentEvent, JSONServerSentEvent
 from sse_starlette.sse import EventSourceResponse
 
-__all__ = ["EventSourceResponse", "ServerSentEvent"]
+__all__ = ["EventSourceResponse", "ServerSentEvent", "JSONServerSentEvent"]
 __version__ = "2.3.6"

--- a/sse_starlette/event.py
+++ b/sse_starlette/event.py
@@ -1,5 +1,6 @@
 import io
 import re
+import json
 from typing import Optional, Any, Union
 
 
@@ -56,6 +57,32 @@ class ServerSentEvent:
 
         buffer.write(self._sep)
         return buffer.getvalue().encode("utf-8")
+
+
+class JSONServerSentEvent(ServerSentEvent):
+    """
+    Helper class to format JSON data for Server-Sent Events (SSE).
+    """
+
+    def __init__(
+        self,
+        data: Optional[Any] = None,
+        *args,
+        **kwargs,
+    ) -> None:
+        super().__init__(
+            json.dumps(
+                data,
+                ensure_ascii=False,
+                allow_nan=False,
+                indent=None,
+                separators=(",", ":"),
+            )
+            if data is not None
+            else None,
+            *args,
+            **kwargs,
+        )
 
 
 def ensure_bytes(data: Union[bytes, dict, ServerSentEvent, Any], sep: str) -> bytes:

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -1,6 +1,6 @@
 import pytest
 
-from sse_starlette.event import ServerSentEvent, ensure_bytes
+from sse_starlette.event import ServerSentEvent, JSONServerSentEvent, ensure_bytes
 
 
 @pytest.mark.parametrize(
@@ -36,6 +36,37 @@ def test_server_sent_event(input, expected):
         assert ServerSentEvent(input).encode() == expected
     else:
         assert ServerSentEvent(**input).encode() == expected
+
+
+@pytest.mark.parametrize(
+    "input, expected",
+    [
+        (dict(data={"foo": "bar"}), b'data: {"foo":"bar"}\r\n\r\n'),
+        (
+            dict(data={"foo": "bar"}, event="baz"),
+            b'event: baz\r\ndata: {"foo":"bar"}\r\n\r\n',
+        ),
+        (
+            dict(data={"foo": "bar"}, event="baz", id="xyz"),
+            b'id: xyz\r\nevent: baz\r\ndata: {"foo":"bar"}\r\n\r\n',
+        ),
+        (
+            dict(data={"foo": "bar"}, event="baz", id="xyz", retry=1),
+            b'id: xyz\r\nevent: baz\r\ndata: {"foo":"bar"}\r\nretry: 1\r\n\r\n',
+        ),
+        (
+            dict(comment="a comment"),
+            b": a comment\r\n\r\n",
+        ),
+        (
+            dict(data={"foo": "bar"}, comment="a comment"),
+            b': a comment\r\ndata: {"foo":"bar"}\r\n\r\n',
+        ),
+    ],
+)
+def test_json_server_sent_event(input, expected):
+    print(input, expected)
+    assert JSONServerSentEvent(**input).encode() == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Using this library manually managing `json.dumps` was quite a chore, so naturally some wrappers were made.

As a continuation of https://github.com/sysid/sse-starlette/issues/21 and https://github.com/sysid/sse-starlette/pull/79, a neat way to improve the QOL of this library would be to provide a neat wrapper that immitates the common `JSONResponse` seen in starlette (https://github.com/encode/starlette/blob/fa5355442753f794965ae1af0f87f9fec1b9a3de/starlette/responses.py#L180).

I've added a simple test case and an entry to the README.md, but let me know if any changes are required. The actual behavior of the class is losely related to `JSONResponse` but `None` is treated as `None` all the way through, not null.