### PR TITLE
Fix Issue #140: Replace global AppStatus.should_exit_event with context-local events

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,7 @@ markers = [
     "experimentation: marks tests as experimental tests, not to be run in CICD"
 ]
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
 #addopts = "--cov=my_package --cov-report=term-missing"
 
 [tool.mypy]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+from contextlib import asynccontextmanager
 
 import httpx
 import pytest
@@ -32,10 +33,12 @@ def anyio_backend():
 
 @pytest.fixture
 async def app():
-    async def startup():
+    @asynccontextmanager
+    async def lifespan(app):
+        # Startup
         _log.debug("Starting up")
-
-    async def shutdown():
+        yield
+        # Shutdown  
         _log.debug("Shutting down")
 
     async def home():
@@ -60,8 +63,7 @@ async def app():
 
     app = Starlette(
         routes=[Route("/", home), Route("/endless", endpoint=endless)],
-        on_startup=[startup],
-        on_shutdown=[shutdown],
+        lifespan=lifespan,
     )
 
     async with LifespanManager(app):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,6 @@ from starlette.routing import Route
 from starlette.testclient import TestClient
 
 from sse_starlette import EventSourceResponse
-from sse_starlette.sse import AppStatus
 
 _log = logging.getLogger(__name__)
 log_fmt = r"%(asctime)-15s %(levelname)s %(name)s %(funcName)s:%(lineno)d %(message)s"
@@ -72,13 +71,7 @@ async def app():
 
 
 @pytest.fixture
-def reset_appstatus_event():
-    # avoid: RuntimeError: <asyncio.locks.Event object at 0x1046a0a30 [unset]> is bound to a different event loop
-    AppStatus.should_exit_event = None
-
-
-@pytest.fixture
-async def httpx_client(reset_appstatus_event, app):
+async def httpx_client(app):
     transport = ASGITransport(app=app)
 
     async with httpx.AsyncClient(
@@ -89,7 +82,7 @@ async def httpx_client(reset_appstatus_event, app):
 
 
 @pytest.fixture
-def client(reset_appstatus_event, app):
+def client(app):
     with TestClient(app=app, base_url="http://localhost:8000") as client:
         print("Yielding Client")
         yield client

--- a/tests/experimentation/test_multiple_consumers_asyncio.py
+++ b/tests/experimentation/test_multiple_consumers_asyncio.py
@@ -1,6 +1,5 @@
 import asyncio
 import logging
-import os
 from contextlib import asynccontextmanager
 from typing import AsyncIterator, List
 import pytest
@@ -50,7 +49,7 @@ class ServerManager:
         self._server_task = asyncio.create_task(self.server.serve())
 
         try:
-            async with timeout(10) as timeout_ctx:  # 10 second timeout for startup
+            async with timeout(10):  # 10 second timeout for startup
                 await self._startup_complete.wait()
 
                 # Additional health check

--- a/tests/test_multi_loop.py
+++ b/tests/test_multi_loop.py
@@ -1,0 +1,196 @@
+"""
+Tests for multi-loop and thread safety scenarios to verify Issue #140 fix.
+"""
+
+import asyncio
+import threading
+import time
+from typing import List
+
+import pytest
+
+from sse_starlette.sse import AppStatus, EventSourceResponse, _exit_event_context
+
+
+class TestMultiLoopSafety:
+    """Test suite for multi-loop and thread safety."""
+
+    def setup_method(self):
+        """Reset AppStatus before each test."""
+        AppStatus.should_exit = False
+
+    def teardown_method(self):
+        """Clean up after each test."""
+        AppStatus.should_exit = False
+
+    def test_context_isolation_same_thread(self):
+        """Test that exit events are isolated between different contexts in same thread."""
+
+        async def create_and_check_event():
+            # Each call should get its own event
+            event1 = AppStatus.get_or_create_exit_event()
+            event2 = AppStatus.get_or_create_exit_event()
+
+            # Should be the same within same context
+            assert event1 is event2
+            return event1
+
+        # Run in different asyncio event loops (different contexts)
+        loop1 = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop1)
+        try:
+            event_a = loop1.run_until_complete(create_and_check_event())
+        finally:
+            loop1.close()
+
+        loop2 = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop2)
+        try:
+            event_b = loop2.run_until_complete(create_and_check_event())
+        finally:
+            loop2.close()
+
+        # Events from different loops should be different objects
+        assert event_a is not event_b
+
+    def test_thread_isolation(self):
+        """Test that exit events are isolated between different threads."""
+        events: List = []
+        errors: List = []
+
+        def create_event_in_thread():
+            """Create an event in a new thread with its own event loop."""
+            try:
+                loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(loop)
+
+                async def get_event():
+                    return AppStatus.get_or_create_exit_event()
+
+                event = loop.run_until_complete(get_event())
+                events.append(event)
+                loop.close()
+            except Exception as e:
+                errors.append(e)
+
+        # Create events in multiple threads
+        threads = []
+        for _ in range(3):
+            thread = threading.Thread(target=create_event_in_thread)
+            threads.append(thread)
+            thread.start()
+
+        # Wait for all threads to complete
+        for thread in threads:
+            thread.join()
+
+        # Should have no errors
+        assert not errors, f"Errors occurred: {errors}"
+
+        # Should have 3 different events
+        assert len(events) == 3
+        assert len(set(id(event) for event in events)) == 3, "Events should be unique"
+
+    def test_exit_signal_propagation_multiple_contexts(self):
+        """Test that exit signals properly propagate to multiple contexts."""
+
+        # Test that exit signal set before waiting works correctly
+        AppStatus.should_exit = True
+
+        async def quick_exit_test():
+            await EventSourceResponse._listen_for_exit_signal()
+            return "exited"
+
+        # Test in single loop first
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            result = loop.run_until_complete(quick_exit_test())
+            assert result == "exited"
+        finally:
+            loop.close()
+
+    @pytest.mark.asyncio
+    async def test_context_cleanup(self):
+        """Test that context variables are properly cleaned up."""
+
+        # Create an event in current context
+        initial_event = AppStatus.get_or_create_exit_event()
+        assert _exit_event_context.get() is initial_event
+
+        # Verify we can create new contexts
+        async def inner_context():
+            # This should create a new event in the task context
+            return AppStatus.get_or_create_exit_event()
+
+        # Create task which runs in a copied context
+        task_event = await asyncio.create_task(inner_context())
+
+        # The task should have access to the same event (context is copied)
+        assert task_event is initial_event
+
+    @pytest.mark.asyncio
+    async def test_exit_before_event_creation(self):
+        """Test that exit signal works even when set before event creation."""
+
+        # Set exit before any event is created
+        AppStatus.should_exit = True
+
+        # This should return immediately without waiting
+        start_time = time.time()
+        await EventSourceResponse._listen_for_exit_signal()
+        elapsed = time.time() - start_time
+
+        # Should return almost immediately (less than 0.1 seconds)
+        assert elapsed < 0.1
+
+    @pytest.mark.asyncio
+    async def test_race_condition_protection(self):
+        """Test protection against race conditions during event setup."""
+
+        # Set exit before creating tasks to avoid hanging
+        AppStatus.should_exit = True
+
+        # Multiple concurrent calls should all work correctly
+        tasks = [
+            asyncio.create_task(EventSourceResponse._listen_for_exit_signal())
+            for _ in range(3)
+        ]
+
+        # All tasks should complete quickly
+        results = await asyncio.gather(*tasks)
+        assert len(results) == 3
+
+    def test_no_global_state_pollution(self):
+        """Test that global state is not polluted between test runs."""
+
+        # Verify clean state
+        assert not AppStatus.should_exit
+        assert _exit_event_context.get(None) is None
+
+        # Create an event
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+
+            async def create_event():
+                return AppStatus.get_or_create_exit_event()
+
+            event = loop.run_until_complete(create_event())
+            assert event is not None
+        finally:
+            loop.close()
+
+        # After loop closes, context should be clean for new contexts
+        # (This test verifies we don't have lingering global state)
+        loop2 = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop2)
+        try:
+
+            async def create_new_event():
+                return AppStatus.get_or_create_exit_event()
+
+            new_event = loop2.run_until_complete(create_new_event())
+            assert new_event is not None
+        finally:
+            loop2.close()

--- a/tests/test_sse.py
+++ b/tests/test_sse.py
@@ -49,7 +49,6 @@ class TestEventSourceResponse:
     )
     async def test_response_send_whenValidInput_thenGeneratesExpectedOutput(
         self,
-        reset_appstatus_event,
         mock_generator,
         input_type,
         separator,
@@ -93,7 +92,7 @@ class TestEventSourceResponse:
         ],
     )
     def test_eventSourceResponse_whenUsingMemoryChannel_thenHandlesAsyncQueueCorrectly(
-        self, reset_appstatus_event, producer_output, expected_sse_response
+        self, producer_output, expected_sse_response
     ):
         """Tests that EventSourceResponse can properly consume data from an async memory channel.
 
@@ -169,9 +168,7 @@ class TestEventSourceResponse:
                     assert "Disconnected from client" in caplog.text
 
     @pytest.mark.anyio
-    async def test_send_whenTimeoutOccurs_thenRaisesSendTimeoutError(
-        self, reset_appstatus_event
-    ):
+    async def test_send_whenTimeoutOccurs_thenRaisesSendTimeoutError(self):
         # Arrange
         # Send timeout is set to 0.5s, but `send` will take 1s. Expect SendTimeoutError.
         cleanup_executed = False
@@ -220,9 +217,7 @@ class TestEventSourceResponse:
         assert headers["x-custom-header"] == "custom-value"
         assert headers["content-type"] == "text/event-stream; charset=utf-8"
 
-    def test_headers_whenCreated_thenHasCorrectCharset(
-        self, reset_appstatus_event, mock_generator
-    ):
+    def test_headers_whenCreated_thenHasCorrectCharset(self, mock_generator):
         # Arrange
         generator = mock_generator(1, 5)
 
@@ -240,9 +235,7 @@ class TestEventSourceResponse:
         assert header_value == "text/event-stream; charset=utf-8"
 
     @pytest.mark.anyio
-    async def test_ping_whenConcurrentWithEvents_thenRespectsLocking(
-        self, reset_appstatus_event
-    ):
+    async def test_ping_whenConcurrentWithEvents_thenRespectsLocking(self):
         # Sequencing here is as follows to reproduce race condition:
         # t=0.5s - event_publisher sends the first response item,
         #          claiming the lock and going to sleep for 1 second so until t=1.5s.
@@ -334,9 +327,7 @@ class TestEventSourceResponse:
         assert result == expected.encode()
 
     @pytest.mark.anyio
-    async def test_backgroundTask_whenProvided_thenExecutesAfterResponse(
-        self, reset_appstatus_event
-    ):
+    async def test_backgroundTask_whenProvided_thenExecutesAfterResponse(self):
         # Arrange
         task_executed = False
 


### PR DESCRIPTION
## Summary

Resolves Issue #140 by eliminating `RuntimeError: asyncio.locks.Event is bound to a different event loop` that occurs when using SSE streams in multi-threaded applications or with multiple asyncio event loops.

## Changes

### Core Implementation
- **Replace global state with context-local events**: Uses `contextvars.ContextVar` to manage exit events per event loop context
- **Add `get_or_create_exit_event()` method**: Creates context-isolated exit events as needed
- **Update exit signal handling**: Modified `handle_exit()` to signal events in current context only
- **Maintain backwards compatibility**: All existing APIs remain unchanged

### Test Improvements
- **Remove test workarounds**: Eliminated `reset_appstatus_event` fixture that was needed to work around the global state issue
- **Add comprehensive multi-loop tests**: New test suite validates thread safety and context isolation
- **Fix deprecation warnings**: Updated to modern Starlette lifespan API and pytest-asyncio configuration

## Benefits

✅ **Thread Safety**: SSE streams now work correctly in multi-threaded applications  
✅ **Event Loop Isolation**: Each context gets its own exit event, preventing cross-loop contamination  
✅ **Clean Test Runs**: Eliminated all deprecation warnings and test workarounds  
✅ **Performance**: Minimal overhead with context variables  

The fix resolves the core issue reported in #140:

**Before**: `RuntimeError: asyncio.locks.Event is bound to a different event loop`  
**After**: SSE streams work correctly across multiple threads and event loops

Multi-threaded usage now works seamlessly:
```python
# This now works without errors
def run_sse_in_thread():
    loop = asyncio.new_event_loop()
    asyncio.set_event_loop(loop)
    # SSE streaming works correctly
    loop.run_until_complete(sse_stream())
    loop.close()
```