### PR TITLE
feat: add enable_automatic_graceful_drain_mode() for re-enabling auto…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.workmux.yaml
 thoughts
 .tox/
 report.xml

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN pip install --no-cache-dir -e .
 
 # Install additional test dependencies if needed
 # You can also add these to pyproject.toml in [project.optional-dependencies]
-RUN pip install --no-cache-dir pytest pytest-asyncio httpx
+RUN pip install --no-cache-dir pytest pytest-asyncio httpx uvicorn
 
 # Copy test files
 COPY tests ./tests

--- a/sse_starlette/sse.py
+++ b/sse_starlette/sse.py
@@ -141,11 +141,25 @@ class AppStatus:
     @staticmethod
     def disable_automatic_graceful_drain():
         """
-        Prevent automatically triggering streams to close on server shutdown. If you call this, you
-        should probably set AppStatus.should_exit at some point during server shutdown manually in
-        your shutdown handler. That will trigger the shutdown logic in about half a second
+        Prevent automatic SSE stream termination on server shutdown.
+
+        WARNING: When disabled, you MUST set AppStatus.should_exit = True
+        at some point during shutdown, or streams will never close and the
+        server will hang indefinitely (or until uvicorn's graceful shutdown
+        timeout expires).
         """
         AppStatus.enable_automatic_graceful_drain = False
+
+    @staticmethod
+    def enable_automatic_graceful_drain_mode():
+        """
+        Re-enable automatic SSE stream termination on server shutdown.
+
+        This restores the default behavior where SIGTERM triggers immediate
+        stream draining. Call this to undo a previous call to
+        disable_automatic_graceful_drain().
+        """
+        AppStatus.enable_automatic_graceful_drain = True
 
     @staticmethod
     def handle_exit(*args, **kwargs):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,7 @@ def reset_shutdown_state():
 
     # Setup: clean state
     AppStatus.should_exit = False
+    AppStatus.enable_automatic_graceful_drain = True
     if hasattr(_thread_state, "shutdown_state"):
         del _thread_state.shutdown_state
 
@@ -42,6 +43,7 @@ def reset_shutdown_state():
 
     # Teardown: signal shutdown to kill any running watchers, then clean up
     AppStatus.should_exit = True
+    AppStatus.enable_automatic_graceful_drain = True
     if hasattr(_thread_state, "shutdown_state"):
         del _thread_state.shutdown_state
 

--- a/tests/integration/test_multiple_consumers.py
+++ b/tests/integration/test_multiple_consumers.py
@@ -14,10 +14,14 @@ class SSEServerContainer(DockerContainer):
         super().__init__("sse_starlette:latest")
         self.app_path = app_path
 
+        # Specify platform for amd64 image on arm64 hosts
+        self.with_kwargs(platform="linux/amd64")
+
         # Mount the current directory into the container
-        self.with_volume_mapping(
-            host="/Users/Q187392/dev/s/public/sse-starlette", container="/app"
-        )
+        import os
+
+        project_root = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+        self.with_volume_mapping(host=project_root, container="/app")
         self.with_name("sse_starlette_test")
         self.with_command(
             f"uvicorn {self.app_path} --host 0.0.0.0 --port 8000 --log-level info"

--- a/tests/test_multi_loop.py
+++ b/tests/test_multi_loop.py
@@ -84,9 +84,9 @@ class TestMultiLoopSafety:
 
         assert not errors, f"Errors occurred: {errors}"
         assert len(states) == 3
-        assert len(set(id(s) for s in states)) == 3, (
-            "States should be unique per thread"
-        )
+        assert (
+            len(set(id(s) for s in states)) == 3
+        ), "States should be unique per thread"
 
 
 class TestIssue149HandleExitSignaling:
@@ -162,9 +162,9 @@ class TestIssue149HandleExitSignaling:
             except asyncio.CancelledError:
                 pass
 
-        assert len(exited) == num_tasks, (
-            f"Only {len(exited)}/{num_tasks} tasks woke up."
-        )
+        assert (
+            len(exited) == num_tasks
+        ), f"Only {len(exited)}/{num_tasks} tasks woke up."
 
     @pytest.mark.asyncio
     async def test_manual_shutdown_ignores_signal(self):
@@ -184,14 +184,14 @@ class TestIssue149HandleExitSignaling:
             AppStatus.original_handler = None
             AppStatus.handle_exit()
             await asyncio.sleep(1.0)
-            assert not task_exited.is_set(), (
-                "Task woke up despite automatic signaling being disabled."
-            )
+            assert (
+                not task_exited.is_set()
+            ), "Task woke up despite automatic signaling being disabled."
             AppStatus.should_exit = True  # Manually signal shutdown
             await asyncio.wait([task], timeout=1.0)
-            assert task_exited.is_set(), (
-                "Task did not wake up after manual shutdown signal."
-            )
+            assert (
+                task_exited.is_set()
+            ), "Task did not wake up after manual shutdown signal."
         finally:
             AppStatus.enable_automatic_graceful_drain = original_drain
             AppStatus.original_handler = original_handler
@@ -218,3 +218,60 @@ class TestIssue149HandleExitSignaling:
             f"Expected all tasks to share one state, but found {len(unique_ids)} unique states. "
             f"This indicates threading.local is not working as expected."
         )
+
+
+class TestUvicornIntrospection:
+    """Tests for uvicorn server introspection bypass when auto-drain is disabled."""
+
+    @pytest.mark.asyncio
+    async def test_uvicorn_should_exit_ignored_when_disabled(self):
+        """
+        Test that uvicorn's should_exit flag is ignored when automatic draining
+        is disabled.
+
+        The _shutdown_watcher checks uvicorn_server.should_exit as a fallback
+        (Issue #132 fix), but this check should be bypassed when the user has
+        disabled automatic draining.
+        """
+        from unittest.mock import MagicMock, patch
+
+        # Create a mock uvicorn server with should_exit=True
+        mock_server = MagicMock()
+        mock_server.should_exit = True
+
+        # IMPORTANT: Disable automatic draining BEFORE starting the watcher
+        # In production, users call this at app startup, before any SSE connections
+        AppStatus.disable_automatic_graceful_drain()
+
+        # Mock _get_uvicorn_server to return our mock
+        with patch("sse_starlette.sse._get_uvicorn_server", return_value=mock_server):
+            task_exited = asyncio.Event()
+
+            async def wait_for_exit():
+                await EventSourceResponse._listen_for_exit_signal()
+                task_exited.set()
+
+            task = asyncio.create_task(wait_for_exit())
+            await asyncio.sleep(0.1)  # Let task start and watcher begin
+
+            # Wait beyond the watcher poll interval (0.5s)
+            # If the uvicorn check weren't bypassed, task would wake up
+            await asyncio.sleep(1.0)
+
+            assert not task_exited.is_set(), "Task woke up from uvicorn.should_exit despite auto-drain being disabled."
+
+            # Now manually signal shutdown
+            AppStatus.should_exit = True
+
+            # Wait for watcher to pick up manual signal
+            try:
+                await asyncio.wait_for(task_exited.wait(), timeout=1.0)
+            except asyncio.TimeoutError:
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+                pytest.fail(
+                    "Task did not wake up after manual AppStatus.should_exit = True"
+                )


### PR DESCRIPTION
Add method to restore default auto-drain behavior after it was disabled, completing the API for controlling graceful shutdown behavior.

Also includes:
- Reset enable_automatic_graceful_drain flag in test fixture for isolation
- Add test for uvicorn introspection bypass when auto-drain disabled
- Fix integration test to use relative project path instead of hardcoded
- Add platform spec for arm64 Docker host compatibility
- Add uvicorn to Dockerfile test dependencies