### PR TITLE
fix: disable keep-alive pings when ping=0 (#206)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -14,6 +14,7 @@ anyio.create_task_group()
    |
    +-- cancel_on_finish(_stream_response)      # pushes SSE data to client
    +-- cancel_on_finish(_ping)                 # keepalive pings every ~15s
+   |                                           # (skipped entirely when ping=0)
    +-- cancel_on_finish(_listen_for_exit_signal_with_grace)  # server shutdown
    +-- cancel_on_finish(_listen_for_disconnect) # client disconnect
    |   (+ optional: data_sender_callable)

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ cancellation on server shutdown.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `content` | `ContentStream` | Required | Async generator or iterable |
-| `ping` | `int` | 15 | Ping interval in seconds (0 to disable) |
+| `ping` | `int` | 15 | Ping interval in seconds (`0` disables keep-alive pings) |
 | `sep` | `str` | `"\r\n"` | Line separator (`\r\n`, `\r`, `\n`) |
 | `send_timeout` | `float` | `None` | Send operation timeout in seconds |
 | `headers` | `dict` | `None` | Additional HTTP headers |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ daphne = [
 [dependency-groups]
 dev = [
     "asgi-lifespan>=2.1.0",
-    "httpx>=0.28.1",
+    "httpx2>=2.12.0",
     "pre-commit>=4.5.0",
     "pytest>=8.3.4",
     "pytest-asyncio>=0.25.0",

--- a/sse_starlette/sse.py
+++ b/sse_starlette/sse.py
@@ -241,7 +241,8 @@ class EventSourceResponse(Response):
         headers: Additional HTTP headers.
         media_type: Response media type. Default: "text/event-stream".
         background: Background task to run after response completes.
-        ping: Ping interval in seconds (0 to disable). Default: 15.
+        ping: Ping interval in seconds. Default: 15. Set to 0 to disable
+            keep-alive pings entirely (no ping task is started).
         sep: Line separator for SSE messages ("\\r\\n", "\\r", or "\\n").
         ping_message_factory: Callable returning custom ping ServerSentEvent.
         data_sender_callable: Async callable for push-based data sending.
@@ -339,9 +340,9 @@ class EventSourceResponse(Response):
     @ping_interval.setter
     def ping_interval(self, value: Union[int, float]) -> None:
         if not isinstance(value, (int, float)):
-            raise TypeError("ping interval must be int")
+            raise TypeError("ping interval must be int or float")
         if value < 0:
-            raise ValueError("ping interval must be greater than 0")
+            raise ValueError("ping interval must be >= 0 (0 disables ping)")
         self._ping_interval = value
 
     def enable_compression(self, force: bool = False) -> None:
@@ -436,6 +437,13 @@ class EventSourceResponse(Response):
         """Periodically send ping messages to keep the connection alive on proxies.
         - frequenccy ca every 15 seconds.
         - Alternatively one can send periodically a comment line (one starting with a ':' character)
+
+        Invariant (Issue #206): must NOT be started when ``ping_interval == 0``
+        (ping disabled), because ``anyio.sleep(0)`` is a bare checkpoint and the
+        loop would busy-spin, flooding the client with pings and contending for
+        ``_send_lock`` with the data stream. ``__call__`` skips the task instead
+        of returning early here, since ``_ping`` runs under ``cancel_on_finish``
+        and any return would tear down the whole response.
         """
         while self.active:
             await anyio.sleep(self._ping_interval)
@@ -485,7 +493,9 @@ class EventSourceResponse(Response):
                 task_group.start_soon(
                     cancel_on_finish, lambda: self._stream_response(send)
                 )
-                task_group.start_soon(cancel_on_finish, lambda: self._ping(send))
+                # ping_interval == 0 disables keep-alive pings entirely (#206)
+                if self._ping_interval > 0:
+                    task_group.start_soon(cancel_on_finish, lambda: self._ping(send))
                 task_group.start_soon(
                     cancel_on_finish, self._listen_for_exit_signal_with_grace
                 )

--- a/sse_starlette/sse.py
+++ b/sse_starlette/sse.py
@@ -267,7 +267,7 @@ class EventSourceResponse(Response):
         headers: Optional[Mapping[str, str]] = None,
         media_type: str = "text/event-stream",
         background: Optional[BackgroundTask] = None,
-        ping: Optional[int] = None,
+        ping: Optional[Union[int, float]] = None,
         sep: Optional[str] = None,
         ping_message_factory: Optional[Callable[[], ServerSentEvent]] = None,
         data_sender_callable: Optional[
@@ -435,7 +435,7 @@ class EventSourceResponse(Response):
 
     async def _ping(self, send: Send) -> None:
         """Periodically send ping messages to keep the connection alive on proxies.
-        - frequenccy ca every 15 seconds.
+        - frequency ca every 15 seconds.
         - Alternatively one can send periodically a comment line (one starting with a ':' character)
 
         Invariant (Issue #206): must NOT be started when ``ping_interval == 0``

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,10 +2,10 @@ import asyncio
 import logging
 from contextlib import asynccontextmanager
 
-import httpx
+import httpx2 as httpx
 import pytest
 from asgi_lifespan import LifespanManager
-from httpx import ASGITransport
+from httpx2 import ASGITransport
 from starlette.applications import Starlette
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse
@@ -19,8 +19,8 @@ log_fmt = r"%(asctime)-15s %(levelname)s %(name)s %(funcName)s:%(lineno)d %(mess
 datefmt = "%Y-%m-%d %H:%M:%S"
 logging.basicConfig(format=log_fmt, level=logging.DEBUG, datefmt=datefmt)
 
-logging.getLogger("httpx").setLevel(logging.INFO)
-logging.getLogger("httpcore").setLevel(logging.INFO)
+logging.getLogger("httpx2").setLevel(logging.INFO)
+logging.getLogger("httpcore2").setLevel(logging.INFO)
 logging.getLogger("urllib3").setLevel(logging.INFO)
 logging.getLogger("docker").setLevel(logging.INFO)
 

--- a/tests/integration/test_multiple_consumers.py
+++ b/tests/integration/test_multiple_consumers.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 
-import httpx
+import httpx2 as httpx
 import pytest
 from testcontainers.core.container import DockerContainer
 from testcontainers.core.wait_strategies import LogMessageWaitStrategy

--- a/tests/test_sse.py
+++ b/tests/test_sse.py
@@ -38,23 +38,7 @@ def mock_memory_channels():
     return setup
 
 
-@pytest.fixture
-def disable_ping(monkeypatch):
-    """Keep serialization tests independent of wall-clock heartbeat timing.
-
-    Scheduler delays can move a real ping across an assertion boundary and make
-    an unrelated formatting test flaky. Ping cadence is covered separately with
-    controlled timer ticks, so these tests only need a cancellable ping task.
-    """
-
-    async def wait_until_cancelled(_response, _send):
-        await anyio.Event().wait()
-
-    monkeypatch.setattr(EventSourceResponse, "_ping", wait_until_cancelled)
-
-
 class TestEventSourceResponse:
-    @pytest.mark.usefixtures("disable_ping")
     @pytest.mark.parametrize(
         "input_type,separator,expected_output",
         [
@@ -86,7 +70,8 @@ class TestEventSourceResponse:
                 async for value in generator:
                     yield await format_output(value)
 
-            response = EventSourceResponse(generate(), sep=separator)
+            # ping=0: keep serialization assertions independent of heartbeat timing
+            response = EventSourceResponse(generate(), sep=separator, ping=0)
             await response(scope, receive, send)
 
         # Act
@@ -96,7 +81,6 @@ class TestEventSourceResponse:
         # Assert
         assert expected_output in response.content
 
-    @pytest.mark.usefixtures("disable_ping")
     @pytest.mark.parametrize(
         "producer_output,expected_sse_response",
         [
@@ -153,6 +137,7 @@ class TestEventSourceResponse:
                 data_sender_callable=partial(
                     stream_numbers, send_chan, 1, 5
                 ),  # Producer writes to send channel
+                ping=0,  # keep assertions independent of heartbeat timing
             )
             await response(scope, receive, send)
 

--- a/tests/test_sse.py
+++ b/tests/test_sse.py
@@ -369,8 +369,55 @@ class TestEventSourceResponse:
         negative_interval = -42
 
         # Act & Assert
-        with pytest.raises(ValueError, match="ping interval must be greater than 0"):
+        with pytest.raises(ValueError, match=r"ping interval must be >= 0"):
             response.ping_interval = negative_interval
+
+    def test_pingInterval_whenZero_thenAcceptedAsDisabled(self):
+        # Arrange
+        response = EventSourceResponse(0)
+
+        # Act
+        response.ping_interval = 0
+
+        # Assert
+        assert response.ping_interval == 0
+
+    @pytest.mark.anyio
+    async def test_ping_whenIntervalIsZero_thenNoPingTaskIsStarted(self):
+        """Issue #206: ping=0 must disable pings, not busy-spin on sleep(0).
+
+        Before the fix, ``_ping`` looped on ``anyio.sleep(0)`` — a bare
+        checkpoint — emitting tens of thousands of pings per second and
+        contending for ``_send_lock`` with the data stream.
+        """
+
+        # Arrange
+        async def gen():
+            for i in range(3):
+                await anyio.sleep(0.01)
+                yield {"data": i}
+
+        response = EventSourceResponse(gen(), ping=0)
+        bodies = []
+
+        async def send(message):
+            if message["type"] == "http.response.body":
+                bodies.append(message["body"])
+
+        async def receive():
+            await anyio.sleep(math.inf)
+            return {"type": "http.disconnect"}  # pragma: no cover
+
+        # Act
+        await response({"type": "http", "method": "GET", "headers": []}, receive, send)
+
+        # Assert
+        assert not any(b": ping" in body for body in bodies)
+        assert [b for b in bodies if b] == [
+            b"data: 0\r\n\r\n",
+            b"data: 1\r\n\r\n",
+            b"data: 2\r\n\r\n",
+        ]
 
     def test_compression_whenEnabled_thenRaisesNotImplemented(self):
         # Arrange

--- a/uv.lock
+++ b/uv.lock
@@ -2,7 +2,8 @@ version = 1
 revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
-    "python_full_version >= '3.11'",
+    "python_full_version >= '3.12' and sys_platform == 'emscripten'",
+    "(python_full_version >= '3.11' and sys_platform != 'emscripten') or (python_full_version == '3.11.*' and sys_platform == 'emscripten')",
     "python_full_version < '3.11'",
 ]
 
@@ -88,10 +89,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "cryptography" },
-    { name = "hyperlink" },
-    { name = "setuptools" },
-    { name = "txaio", version = "25.9.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "cryptography", marker = "python_full_version < '3.11'" },
+    { name = "hyperlink", marker = "python_full_version < '3.11'" },
+    { name = "setuptools", marker = "python_full_version < '3.11'" },
+    { name = "txaio", version = "25.9.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/38/f2/8dffb3b709383ba5b47628b0cc4e43e8d12d59eecbddb62cfccac2e7cf6a/autobahn-24.4.2.tar.gz", hash = "sha256:a2d71ef1b0cf780b6d11f8b205fd2c7749765e65795f2ea7d823796642ee92c9", size = 482700, upload-time = "2024-08-02T09:26:48.241Z" }
 wheels = [
@@ -103,18 +104,19 @@ name = "autobahn"
 version = "25.12.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.11'",
+    "python_full_version >= '3.12' and sys_platform == 'emscripten'",
+    "(python_full_version >= '3.11' and sys_platform != 'emscripten') or (python_full_version == '3.11.*' and sys_platform == 'emscripten')",
 ]
 dependencies = [
-    { name = "cbor2" },
-    { name = "cffi" },
-    { name = "cryptography" },
-    { name = "hyperlink" },
-    { name = "msgpack", marker = "platform_python_implementation == 'CPython'" },
-    { name = "py-ubjson" },
-    { name = "txaio", version = "25.12.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "u-msgpack-python", marker = "platform_python_implementation != 'CPython'" },
-    { name = "ujson" },
+    { name = "cbor2", marker = "python_full_version >= '3.11'" },
+    { name = "cffi", marker = "python_full_version >= '3.11'" },
+    { name = "cryptography", marker = "python_full_version >= '3.11'" },
+    { name = "hyperlink", marker = "python_full_version >= '3.11'" },
+    { name = "msgpack", marker = "python_full_version >= '3.11' and platform_python_implementation == 'CPython'" },
+    { name = "py-ubjson", marker = "python_full_version >= '3.11'" },
+    { name = "txaio", version = "25.12.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "u-msgpack-python", marker = "python_full_version >= '3.11' and platform_python_implementation != 'CPython'" },
+    { name = "ujson", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e2/1a/ac15ba19cb6a5d2a3371fec8d5ffa7a92104973aeb60d65ca85c69a17c29/autobahn-25.12.1.tar.gz", hash = "sha256:a13e49f762e97a291136bb1c4e39e6b026c4275593fb1d9ef9b73e7ef22e559d", size = 13851285, upload-time = "2025-12-10T02:43:46.543Z" }
 wheels = [
@@ -621,7 +623,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -807,31 +809,42 @@ wheels = [
 ]
 
 [[package]]
-name = "httpcore"
-version = "1.0.9"
+name = "httpcore2"
+version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "certifi" },
-    { name = "h11" },
+    { name = "h11", marker = "python_full_version < '3.12' or sys_platform != 'emscripten'" },
+    { name = "truststore", marker = "python_full_version < '3.12' or sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/ad/f4f0e57345f1870f3e8cb624e058d7eca6e5a27d33bcc3311d9b618734cd/httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648", size = 67548, upload-time = "2026-08-18T13:22:08.211Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/74/d370e55600d9bcfa0d9794b0166126d49291a3d2b20c268fc98c453a4948/httpcore2-2.12.0-py3-none-any.whl", hash = "sha256:7e04258ce01013d7d615e5b910a3b27fac937d7a95038227e79652b4ba3b4ceb", size = 83074, upload-time = "2026-08-18T13:22:05.854Z" },
 ]
 
 [[package]]
-name = "httpx"
-version = "0.28.1"
+name = "httpx2"
+version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "certifi" },
-    { name = "httpcore" },
+    { name = "anyio", marker = "sys_platform != 'emscripten'" },
+    { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "python_full_version >= '3.12' and sys_platform == 'emscripten'" },
     { name = "idna" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7f/f8/579a8b51e42e38ee32647df9f08aa25643ae788e275cc625b199829c4671/httpx2-2.12.0.tar.gz", hash = "sha256:7631fe9887a8a2275f4a2540e053aa670fcc50742864a9ae7c66e609fdcf12cf", size = 100040, upload-time = "2026-08-18T13:22:09.086Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/411ba65569158e862368917aaf56597f3e5fa3b91b0502919638465a08f3/httpx2-2.12.0-py3-none-any.whl", hash = "sha256:cc8b6eecb8661c146b8f89a60e97456ee086e91a784ed31ac450c3a9e613dd36", size = 95427, upload-time = "2026-08-18T13:22:06.834Z" },
+]
+
+[[package]]
+name = "httpx2-jsfetch"
+version = "1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872, upload-time = "2026-08-07T00:13:07.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382, upload-time = "2026-08-07T00:13:06.567Z" },
 ]
 
 [[package]]
@@ -857,11 +870,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.15"
+version = "3.19"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/f7/abb373e5757eaec4b922b92f97ec8d6d7e057cf06778247604fbc4e7c3f3/idna-3.19.tar.gz", hash = "sha256:5e0811a4383b21dc5838069f801c4fb62113b7447663d2530d2bd6e77b49bf15", size = 215237, upload-time = "2026-08-18T05:14:24.27Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
+    { url = "https://files.pythonhosted.org/packages/57/b0/0e52c878c53f245edd3a11020f20979b3f490f245af532c7cae3027754b5/idna-3.19-py3-none-any.whl", hash = "sha256:815e7be7a7806d54abb586dc943addc79e8b2ee16915059658cbeff4b1b43bf4", size = 68550, upload-time = "2026-08-18T05:14:22.343Z" },
 ]
 
 [[package]]
@@ -1553,7 +1566,7 @@ asyncio = [
 
 [[package]]
 name = "sse-starlette"
-version = "3.4.6"
+version = "3.4.8"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },
@@ -1583,7 +1596,7 @@ uvicorn = [
 [package.dev-dependencies]
 dev = [
     { name = "asgi-lifespan" },
-    { name = "httpx" },
+    { name = "httpx2" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -1617,7 +1630,7 @@ provides-extras = ["examples", "examples-db", "uvicorn", "granian", "daphne"]
 [package.metadata.requires-dev]
 dev = [
     { name = "asgi-lifespan", specifier = ">=2.1.0" },
-    { name = "httpx", specifier = ">=0.28.1" },
+    { name = "httpx2", specifier = ">=2.12.0" },
     { name = "pre-commit", specifier = ">=4.5.0" },
     { name = "pytest", specifier = ">=8.3.4" },
     { name = "pytest-asyncio", specifier = ">=0.25.0" },
@@ -1734,6 +1747,15 @@ wheels = [
 ]
 
 [[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
+]
+
+[[package]]
 name = "twisted"
 version = "26.4.0rc2"
 source = { registry = "https://pypi.org/simple" }
@@ -1775,7 +1797,8 @@ name = "txaio"
 version = "25.12.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.11'",
+    "python_full_version >= '3.12' and sys_platform == 'emscripten'",
+    "(python_full_version >= '3.11' and sys_platform != 'emscripten') or (python_full_version == '3.11.*' and sys_platform == 'emscripten')",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7f/67/ea9c9ddbaa3e0b4d53c91f8778a33e42045be352dc7200ed2b9aaa7dc229/txaio-25.12.2.tar.gz", hash = "sha256:9f232c21e12aa1ff52690e365b5a0ecfd42cc27a6ec86e1b92ece88f763f4b78", size = 117393, upload-time = "2025-12-09T15:03:26.527Z" }
 wheels = [


### PR DESCRIPTION
The docs promised "0 to disable" but _ping had no disable branch, so ping=0 looped on anyio.sleep(0) — a bare checkpoint. That busy-spun the event loop, flooded the client with ~30k ping comments per second, and contended for _send_lock with the data stream, delaying real events.

__call__ now skips spawning the _ping task entirely when the interval is 0. The guard lives at the spawn site rather than as an early return in _ping, because _ping runs under cancel_on_finish and any return would tear down the whole response; the invariant is recorded in its docstring.