### PR TITLE
fix: apply send timeout to heartbeat messages

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -194,6 +194,11 @@ _stream_response                    _exit_signal_with_grace
 
 ## Flow 5: Send Timeout
 
+`send_timeout` is applied by `_send_with_timeout()`, which both writing tasks
+share. There are therefore **two** origins, and they clean up differently.
+
+### 5a: Data send times out
+
 ```
 _stream_response         _ping        _exit_signal    _disconnect
       |                    |               |               |
@@ -203,13 +208,48 @@ _stream_response         _ping        _exit_signal    _disconnect
         [send hangs!]      |               |               |
            ...             |               |               |
     [timeout expires]      |               |               |
-    cancel_called = True   |               |               |
+    timeout detected       |               |               |
     aclose() iterator      |               |               |
     raise SendTimeoutError |               |               |
       |                    |               |               |
   EXCEPTION propagates through cancel_on_finish into task group
   Task group cancels all siblings
 ```
+
+### 5b: Heartbeat send times out (idle stream)
+
+The case `send_timeout` exists for: the client keeps the socket open but stops
+reading, so no `http.disconnect` ever arrives and the heartbeat is the only
+traffic. Before this path was covered, `_ping` blocked forever *while holding
+`_send_lock`*, which also deadlocked `_stream_response`'s terminal send.
+
+```
+_stream_response         _ping        _exit_signal    _disconnect
+      |                    |               |               |
+  suspended in       await sleep(interval) |               |
+  __anext__()             |                |               |
+  (generator idle)   async with _send_lock:|               |
+      |              move_on_after(timeout):               |
+      |                send(ping)          |               |
+      |                  [send hangs!]     |               |
+      |              [timeout expires]     |               |
+      |              timeout detected      |               |
+      |              raise SendTimeoutError|               |
+      |                    |               |               |
+  EXCEPTION propagates through cancel_on_finish into task group
+  Task group cancels all siblings
+      |                    |               |               |
+  CancelledError thrown into the suspended __anext__
+  Generator's finally block runs
+```
+
+**Why 5b does not `aclose()` the iterator.** `_stream_response` can close the
+iterator explicitly because it owns it and is not inside it at that moment.
+`_ping` cannot: `_stream_response` is typically suspended inside
+`body_iterator.__anext__()`, where `ag_running_async` is set, and `aclose()`
+would raise `RuntimeError: aclose(): asynchronous generator is already running`.
+Cancellation already finalizes the generator, so the ping path relies on that.
+Asserted by `test_ping_whenSendTimesOut_thenTearsDownResponseAndRunsCleanup`.
 
 ---
 
@@ -269,5 +309,6 @@ One watcher per thread broadcasts to all connections in that thread.
 | Server shutdown (no grace) | `_listen_for_exit_signal_with_grace` | CancelledError |
 | Server shutdown (with grace, generator cooperates) | `_stream_response` | Clean exit, farewell sent |
 | Server shutdown (with grace, generator ignores) | `_listen_for_exit_signal_with_grace` (after timeout) | CancelledError |
-| Send timeout | `_stream_response` (via exception) | SendTimeoutError |
+| Send timeout (data) | `_stream_response` (via exception) | SendTimeoutError, iterator `aclose()`d |
+| Send timeout (heartbeat) | `_ping` (via exception) | SendTimeoutError, finalized by task-group cancellation |
 | Client disconnect during grace | `_listen_for_disconnect` | Grace period cut short |

--- a/sse_starlette/sse.py
+++ b/sse_starlette/sse.py
@@ -371,7 +371,7 @@ class EventSourceResponse(Response):
             try:
                 await self._send_with_timeout(
                     send,
-                    {"type": "http.response.body", "body": chunk, "more_body": True}
+                    {"type": "http.response.body", "body": chunk, "more_body": True},
                 )
             except SendTimeoutError:
                 aclose = getattr(self.body_iterator, "aclose", None)
@@ -465,7 +465,7 @@ class EventSourceResponse(Response):
                             "type": "http.response.body",
                             "body": ping_bytes,
                             "more_body": True,
-                        }
+                        },
                     )
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:

--- a/sse_starlette/sse.py
+++ b/sse_starlette/sse.py
@@ -459,6 +459,16 @@ class EventSourceResponse(Response):
 
             async with self._send_lock:
                 if self.active:
+                    # A SendTimeoutError raised here deliberately does NOT
+                    # aclose() the body iterator, unlike _stream_response. When a
+                    # heartbeat times out, _stream_response is normally suspended
+                    # inside body_iterator.__anext__(), where ag_running_async is
+                    # set, so aclose() would raise "RuntimeError: aclose():
+                    # asynchronous generator is already running" (verified).
+                    # Propagating instead lets the task group cancel
+                    # _stream_response, which throws into the suspended
+                    # __anext__ and runs the generator's finally block -- see
+                    # test_ping_whenSendTimesOut_thenTearsDownResponseAndRunsCleanup.
                     await self._send_with_timeout(
                         send,
                         {

--- a/sse_starlette/sse.py
+++ b/sse_starlette/sse.py
@@ -245,7 +245,7 @@ class EventSourceResponse(Response):
         sep: Line separator for SSE messages ("\\r\\n", "\\r", or "\\n").
         ping_message_factory: Callable returning custom ping ServerSentEvent.
         data_sender_callable: Async callable for push-based data sending.
-        send_timeout: Timeout in seconds for individual send operations.
+        send_timeout: Timeout in seconds for individual data or heartbeat sends.
         client_close_handler_callable: Async callback on client disconnect.
         shutdown_event: Optional ``anyio.Event`` set by the library when server
             shutdown is detected. Generators can watch this event to send farewell
@@ -347,6 +347,14 @@ class EventSourceResponse(Response):
     def enable_compression(self, force: bool = False) -> None:
         raise NotImplementedError("Compression is not supported for SSE streams.")
 
+    async def _send_with_timeout(self, send: Send, message: Message) -> None:
+        """Send one ASGI message, applying the response's per-send timeout."""
+        with anyio.move_on_after(self.send_timeout) as cancel_scope:
+            await send(message)
+
+        if cancel_scope and cancel_scope.cancel_called:
+            raise SendTimeoutError()
+
     async def _stream_response(self, send: Send) -> None:
         """Send out SSE data to the client as it becomes available in the iterator."""
         await send(
@@ -360,12 +368,12 @@ class EventSourceResponse(Response):
         async for data in self.body_iterator:
             chunk = ensure_bytes(data, self.sep)
             logger.debug("chunk: %s", chunk)
-            with anyio.move_on_after(self.send_timeout) as cancel_scope:
-                await send(
+            try:
+                await self._send_with_timeout(
+                    send,
                     {"type": "http.response.body", "body": chunk, "more_body": True}
                 )
-
-            if cancel_scope and cancel_scope.cancel_called:
+            except SendTimeoutError:
                 aclose = getattr(self.body_iterator, "aclose", None)
                 if aclose is not None:
                     await aclose()
@@ -451,7 +459,8 @@ class EventSourceResponse(Response):
 
             async with self._send_lock:
                 if self.active:
-                    await send(
+                    await self._send_with_timeout(
+                        send,
                         {
                             "type": "http.response.body",
                             "body": ping_bytes,

--- a/sse_starlette/sse.py
+++ b/sse_starlette/sse.py
@@ -377,7 +377,7 @@ class EventSourceResponse(Response):
                 aclose = getattr(self.body_iterator, "aclose", None)
                 if aclose is not None:
                     await aclose()
-                raise SendTimeoutError()
+                raise
 
         async with self._send_lock:
             self.active = False

--- a/tests/test_sse.py
+++ b/tests/test_sse.py
@@ -328,6 +328,49 @@ class TestEventSourceResponse:
                 await response._ping(blocked_send)
 
     @pytest.mark.anyio
+    async def test_ping_whenSendTimesOut_thenTearsDownResponseAndRunsCleanup(self):
+        """A heartbeat timeout must tear down the whole response, not just _ping.
+
+        This is the frozen-client case the send timeout exists for: the peer keeps
+        the socket open but stops reading, so no http.disconnect ever arrives and
+        the heartbeat is the only traffic. Unlike the unit test above, this drives
+        the full ASGI entrypoint and asserts the generator's cleanup still runs.
+        """
+
+        # Arrange
+        cleanup_executed = False
+
+        async def event_publisher():
+            try:
+                await anyio.sleep_forever()
+                yield {"event": "test", "data": "data"}
+            finally:
+                nonlocal cleanup_executed
+                cleanup_executed = True
+
+        async def mock_send(message):
+            if message["type"] == "http.response.start":
+                return
+            await anyio.sleep_forever()
+
+        async def mock_receive():
+            await anyio.sleep_forever()
+
+        response = EventSourceResponse(event_publisher(), ping=0.05, send_timeout=0.05)
+
+        # Act & Assert
+        with anyio.fail_after(5):
+            with pytest.raises(SendTimeoutError):
+                with collapse_excgroups():
+                    await response(
+                        {"type": "http", "method": "GET", "headers": []},
+                        mock_receive,
+                        mock_send,
+                    )
+
+        assert cleanup_executed, "Generator cleanup must run when a heartbeat times out"
+
+    @pytest.mark.anyio
     async def test_ping_whenConcurrentWithEvents_thenRespectsLocking(self):
         # Sequencing here is as follows to reproduce race condition:
         # t=0.5s - event_publisher sends the first response item,

--- a/tests/test_sse.py
+++ b/tests/test_sse.py
@@ -2,7 +2,6 @@ import asyncio
 import logging
 import math
 from functools import partial
-from types import SimpleNamespace
 
 import anyio
 import anyio.lowlevel
@@ -285,10 +284,7 @@ class TestEventSourceResponse:
             if len(sent_messages) == expected_ping_count:
                 response.active = False
 
-        monkeypatch.setattr(
-            "sse_starlette.sse.anyio",
-            SimpleNamespace(sleep=counted_sleep),
-        )
+        monkeypatch.setattr("sse_starlette.sse.anyio.sleep", counted_sleep)
 
         # Act
         await response._ping(send)
@@ -301,6 +297,19 @@ class TestEventSourceResponse:
             "more_body": True,
         }
         assert sent_messages == [expected_ping_message] * expected_ping_count
+
+    @pytest.mark.anyio
+    async def test_ping_whenSendTimesOut_thenRaisesSendTimeoutError(self):
+        """Heartbeats must honor the response's per-send timeout."""
+
+        response = EventSourceResponse([], ping=0.01, send_timeout=0.01)
+
+        async def blocked_send(_message):
+            await anyio.sleep_forever()
+
+        with anyio.fail_after(0.1):
+            with pytest.raises(SendTimeoutError):
+                await response._ping(blocked_send)
 
     @pytest.mark.anyio
     async def test_ping_whenConcurrentWithEvents_thenRespectsLocking(self):

--- a/tests/test_sse.py
+++ b/tests/test_sse.py
@@ -299,15 +299,31 @@ class TestEventSourceResponse:
         assert sent_messages == [expected_ping_message] * expected_ping_count
 
     @pytest.mark.anyio
-    async def test_ping_whenSendTimesOut_thenRaisesSendTimeoutError(self):
-        """Heartbeats must honor the response's per-send timeout."""
+    async def test_ping_whenSendTimesOut_thenRaisesSendTimeoutError(self, monkeypatch):
+        """Heartbeats must honor the response's per-send timeout.
 
-        response = EventSourceResponse([], ping=0.01, send_timeout=0.01)
+        The ping interval is advanced by a logical tick, following
+        test_ping_whenTimerTicks_thenSendsOneMessagePerTick, so send_timeout is
+        the only real timer in play and the result does not depend on machine
+        load. fail_after is a hang watchdog, not an assertion, so it is set
+        generously.
+        """
+
+        # Arrange
+        send_timeout = 0.05
+
+        async def instant_sleep(_interval):
+            await anyio.lowlevel.checkpoint()
+
+        monkeypatch.setattr("sse_starlette.sse.anyio.sleep", instant_sleep)
+
+        response = EventSourceResponse([], ping=10, send_timeout=send_timeout)
 
         async def blocked_send(_message):
             await anyio.sleep_forever()
 
-        with anyio.fail_after(0.1):
+        # Act & Assert
+        with anyio.fail_after(5):
             with pytest.raises(SendTimeoutError):
                 await response._ping(blocked_send)
 


### PR DESCRIPTION
## Summary

Apply `send_timeout` to heartbeat writes as well as data-event writes.

Previously, an idle stream with a slow or frozen client could block forever in
`_ping()`, even when `send_timeout` was configured. This could retain the SSE
connection and contend with the data stream's send lock.

## Changes

- centralize timeout-protected ASGI sends in `_send_with_timeout()`;
- use it for SSE data events and heartbeat messages;
- add a regression test for a blocked heartbeat send.

## Validation

RUN_ENV=local python -m pytest --ignore=tests/experimentation \
  -m 'not (integration or experimentation)' \
  --cov-config=pyproject.toml --cov-report=term --cov=sse_starlette tests

Result: 79 passed, 2 deselected; coverage 92.93%.