### PR TITLE
fix(examples): handle slow broadcasting clients

### DIFF
--- a/examples/02_broadcasting.py
+++ b/examples/02_broadcasting.py
@@ -101,12 +101,21 @@ class BroadcastStream:
                 raise StopAsyncIteration
             return message
 
-        except asyncio.CancelledError:
+        except BaseException:
+            # BaseException on purpose: asyncio.CancelledError is not an
+            # Exception, and cancellation is how EventSourceResponse stops
+            # this stream on client disconnect.
             await self._cleanup()
             raise
-        except Exception:
-            await self._cleanup()
-            raise
+
+    async def aclose(self) -> None:
+        """
+        Close the stream like an async generator would.
+
+        EventSourceResponse calls aclose() on the body iterator when a send
+        times out. Without this method a timed-out client stays registered.
+        """
+        await self._cleanup()
 
     async def _cleanup(self):
         """
@@ -173,8 +182,11 @@ class MessageBroadcaster:
 
         Design choice: We use bounded queues and put_nowait() so a slow client
         cannot consume unbounded memory or block delivery to healthy clients.
-        A client whose queue fills is disconnected because dropping events could
-        leave it with an incomplete event history.
+        A client whose queue fills is disconnected rather than having events
+        dropped. Either way it misses events; disconnecting makes the gap
+        visible so the client can reconnect and resync. This example sends no
+        event ids, so a real application should add ids and honor
+        Last-Event-ID to make that resync possible.
         """
         if not self._clients:
             return

--- a/examples/02_broadcasting.py
+++ b/examples/02_broadcasting.py
@@ -47,6 +47,14 @@ from starlette.requests import Request
 from sse_starlette import EventSourceResponse, ServerSentEvent
 
 
+class _ClientDisconnect:
+    """Sentinel used to terminate an evicted client's stream."""
+
+
+_DISCONNECT = _ClientDisconnect()
+_QueueItem = ServerSentEvent | _ClientDisconnect
+
+
 class BroadcastStream:
     """
     Stream that connects a client to a broadcaster for receiving SSE events.
@@ -58,7 +66,7 @@ class BroadcastStream:
     def __init__(self, request: Request, broadcaster: "MessageBroadcaster"):
         self.request = request
         self.broadcaster = broadcaster
-        self.queue: Optional[asyncio.Queue] = None
+        self.queue: Optional[asyncio.Queue[_QueueItem]] = None
         self._registered = False
 
     def __aiter__(self) -> "BroadcastStream":
@@ -83,14 +91,19 @@ class BroadcastStream:
         """
         try:
             if await self.request.is_disconnected():
-                await self._cleanup()
                 raise StopAsyncIteration
 
             # Wait for next message from broadcaster
             # This blocks until a message is broadcast to all clients
+            assert self.queue is not None
             message = await self.queue.get()
+            if isinstance(message, _ClientDisconnect):
+                raise StopAsyncIteration
             return message
 
+        except asyncio.CancelledError:
+            await self._cleanup()
+            raise
         except Exception:
             await self._cleanup()
             raise
@@ -115,18 +128,23 @@ class MessageBroadcaster:
     - Backpressure: individual queues can be managed independently
     """
 
-    def __init__(self):
-        self._clients: List[asyncio.Queue] = []
+    def __init__(self, max_queue_size: int = 100):
+        if max_queue_size <= 0:
+            raise ValueError("max_queue_size must be greater than zero")
+        self._max_queue_size = max_queue_size
+        self._clients: List[asyncio.Queue[_QueueItem]] = []
 
-    def add_client(self) -> asyncio.Queue:
+    def add_client(self) -> asyncio.Queue[_QueueItem]:
         """
         Register a new client and return their dedicated message queue.
         """
-        client_queue = asyncio.Queue()
+        client_queue: asyncio.Queue[_QueueItem] = asyncio.Queue(
+            maxsize=self._max_queue_size
+        )
         self._clients.append(client_queue)
         return client_queue
 
-    def remove_client(self, client_queue: asyncio.Queue) -> None:
+    def remove_client(self, client_queue: asyncio.Queue[_QueueItem]) -> None:
         """
         Remove a disconnected client's queue.
 
@@ -136,6 +154,16 @@ class MessageBroadcaster:
         if client_queue in self._clients:
             self._clients.remove(client_queue)
 
+    def disconnect_client(self, client_queue: asyncio.Queue[_QueueItem]) -> None:
+        """Evict a slow client and terminate its stream immediately."""
+        self.remove_client(client_queue)
+
+        # A full queue cannot accept the disconnect sentinel. Discard buffered
+        # events because this client's stream is being terminated anyway.
+        while not client_queue.empty():
+            client_queue.get_nowait()
+        client_queue.put_nowait(_DISCONNECT)
+
     async def broadcast(self, message: str, event: Optional[str] = None) -> None:
         """
         Send a message to ALL connected clients simultaneously.
@@ -143,9 +171,10 @@ class MessageBroadcaster:
         This creates one ServerSentEvent and puts it into every client's queue.
         Each client's BroadcastStream will then yield this event independently.
 
-        Design choice: We use put_nowait() to avoid blocking if a client's
-        queue is full. In production, you might want to handle QueueFull
-        exceptions by either dropping the message or disconnecting slow clients.
+        Design choice: We use bounded queues and put_nowait() so a slow client
+        cannot consume unbounded memory or block delivery to healthy clients.
+        A client whose queue fills is disconnected because dropping events could
+        leave it with an incomplete event history.
         """
         if not self._clients:
             return
@@ -162,7 +191,7 @@ class MessageBroadcaster:
                 disconnected_clients.append(client_queue)
 
         for client_queue in disconnected_clients:
-            self.remove_client(client_queue)
+            self.disconnect_client(client_queue)
 
     def create_stream(self, request: Request) -> BroadcastStream:
         """

--- a/tests/test_broadcasting_example.py
+++ b/tests/test_broadcasting_example.py
@@ -1,0 +1,73 @@
+import asyncio
+import importlib.util
+from pathlib import Path
+import sys
+import types
+
+import pytest
+
+
+@pytest.fixture
+def broadcasting_example(monkeypatch):
+    class FakeFastAPI:
+        def get(self, _path):
+            return lambda endpoint: endpoint
+
+        post = get
+
+    fastapi = types.ModuleType("fastapi")
+    fastapi.FastAPI = FakeFastAPI
+    pydantic = types.ModuleType("pydantic")
+    pydantic.BaseModel = object
+    monkeypatch.setitem(sys.modules, "fastapi", fastapi)
+    monkeypatch.setitem(sys.modules, "pydantic", pydantic)
+
+    example_path = Path(__file__).parents[1] / "examples" / "02_broadcasting.py"
+    spec = importlib.util.spec_from_file_location("broadcasting_example", example_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class ConnectedRequest:
+    async def is_disconnected(self) -> bool:
+        return False
+
+
+def test_client_queues_are_bounded(broadcasting_example):
+    broadcaster = broadcasting_example.MessageBroadcaster()
+
+    queue = broadcaster.add_client()
+
+    assert queue.maxsize > 0
+
+
+async def test_slow_client_stream_stops_immediately(broadcasting_example):
+    broadcaster = broadcasting_example.MessageBroadcaster(max_queue_size=1)
+    stream = broadcaster.create_stream(ConnectedRequest())
+    stream.__aiter__()
+    assert stream.queue is not None
+
+    await broadcaster.broadcast("buffered")
+    await broadcaster.broadcast("triggers eviction")
+
+    with pytest.raises(StopAsyncIteration):
+        await asyncio.wait_for(anext(stream), timeout=0.1)
+
+    assert broadcaster.client_count == 0
+
+
+async def test_cancelled_stream_removes_client(broadcasting_example):
+    broadcaster = broadcasting_example.MessageBroadcaster()
+    stream = broadcaster.create_stream(ConnectedRequest())
+    stream.__aiter__()
+
+    next_event = asyncio.create_task(anext(stream))
+    await asyncio.sleep(0)
+    next_event.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await next_event
+
+    assert broadcaster.client_count == 0

--- a/tests/test_broadcasting_example.py
+++ b/tests/test_broadcasting_example.py
@@ -24,8 +24,8 @@ def broadcasting_example(monkeypatch):
 
     example_path = Path(__file__).parents[1] / "examples" / "02_broadcasting.py"
     spec = importlib.util.spec_from_file_location("broadcasting_example", example_path)
+    assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
-    assert spec.loader is not None
     spec.loader.exec_module(module)
     return module
 
@@ -35,7 +35,7 @@ class ConnectedRequest:
         return False
 
 
-def test_client_queues_are_bounded(broadcasting_example):
+def test_addClient_whenCalled_thenQueueIsBounded(broadcasting_example):
     broadcaster = broadcasting_example.MessageBroadcaster()
 
     queue = broadcaster.add_client()
@@ -43,22 +43,32 @@ def test_client_queues_are_bounded(broadcasting_example):
     assert queue.maxsize > 0
 
 
-async def test_slow_client_stream_stops_immediately(broadcasting_example):
+async def test_broadcast_whenClientQueueFull_thenSlowClientEvictedAndPeerUnaffected(
+    broadcasting_example,
+):
+    # Both clients get a queue of size 1. The healthy client keeps consuming,
+    # the slow client never does, so only the slow queue overflows.
     broadcaster = broadcasting_example.MessageBroadcaster(max_queue_size=1)
-    stream = broadcaster.create_stream(ConnectedRequest())
-    stream.__aiter__()
-    assert stream.queue is not None
+    slow_stream = broadcaster.create_stream(ConnectedRequest())
+    slow_stream.__aiter__()
+    healthy_stream = broadcaster.create_stream(ConnectedRequest())
+    healthy_stream.__aiter__()
+    assert broadcaster.client_count == 2
 
-    await broadcaster.broadcast("buffered")
-    await broadcaster.broadcast("triggers eviction")
+    await broadcaster.broadcast("first")
+    first_event = await anext(healthy_stream)
+    assert first_event.data == "first"
+
+    await broadcaster.broadcast("second")
 
     with pytest.raises(StopAsyncIteration):
-        await asyncio.wait_for(anext(stream), timeout=0.1)
+        await asyncio.wait_for(anext(slow_stream), timeout=0.1)
+    second_event = await asyncio.wait_for(anext(healthy_stream), timeout=0.1)
+    assert second_event.data == "second"
+    assert broadcaster.client_count == 1
 
-    assert broadcaster.client_count == 0
 
-
-async def test_cancelled_stream_removes_client(broadcasting_example):
+async def test_anext_whenCancelled_thenClientRemoved(broadcasting_example):
     broadcaster = broadcasting_example.MessageBroadcaster()
     stream = broadcaster.create_stream(ConnectedRequest())
     stream.__aiter__()
@@ -69,5 +79,18 @@ async def test_cancelled_stream_removes_client(broadcasting_example):
 
     with pytest.raises(asyncio.CancelledError):
         await next_event
+
+    assert broadcaster.client_count == 0
+
+
+async def test_aclose_whenCalled_thenClientRemoved(broadcasting_example):
+    # EventSourceResponse calls aclose() on the body iterator after a send
+    # timeout; without it the evicted client would stay registered.
+    broadcaster = broadcasting_example.MessageBroadcaster()
+    stream = broadcaster.create_stream(ConnectedRequest())
+    stream.__aiter__()
+    assert broadcaster.client_count == 1
+
+    await stream.aclose()
 
     assert broadcaster.client_count == 0


### PR DESCRIPTION
## Summary

- bound each broadcasting client's queue so slow consumers cannot grow memory without limit
- disconnect slow clients when their queue fills and wake their stream with a sentinel
- clean up registered clients when `EventSourceResponse` cancels the iterator on disconnect
- add regression coverage for bounded queues, slow-client eviction, and cancellation cleanup

## Root cause

The example used `asyncio.Queue()` with the default `maxsize=0`, so its `QueueFull` branch was unreachable. Simply bounding the queue was not sufficient: removing a full queue from the broadcaster did not terminate the corresponding stream, which could later wait forever for another event. In addition, `asyncio.CancelledError` is not caught by `except Exception`, so normal response cancellation could leave the client registered.

The example now uses a bounded queue with an explicit disconnect policy. When a queue fills, buffered events are discarded and a sentinel terminates the evicted stream immediately; other clients continue receiving events through `put_nowait()`.

## Verification

- `make test-unit` — 81 passed, 2 deselected
- `make ty`
- `uv run ruff check examples/02_broadcasting.py tests/test_broadcasting_example.py`
- `uv run ruff format --check examples/02_broadcasting.py tests/test_broadcasting_example.py`
